### PR TITLE
Prevent overshooting the points shader progress

### DIFF
--- a/src/js/LightPanel/LightPanelBase.js
+++ b/src/js/LightPanel/LightPanelBase.js
@@ -323,7 +323,7 @@ export default class LightPanel extends Component {
     renderEffects = () => {
         if(this.pointsShader && this.pointsShader.uniforms.progress.value < 1.0) {
             // Fly-in over 3 seconds
-            this.pointsShader.uniforms.progress.value += this.particleClock.getDelta() / 3.0;
+            this.pointsShader.uniforms.progress.value = Math.min(this.particleClock.getElapsedTime() / 3.0, 1.0);
         }
 
         this.renderer.render( this.scene, this.camera );


### PR DESCRIPTION
There's an interesting quirk that can happen if you change tabs during the fly-in or the browser otherwise throttles `renderEffects()` calls: when `renderEffects()` is next called, the elapsed time is added to progress regardless of how much this causes it to overshoot the desired 1.0, and the vertex shader dutifully extrapolates some nonsense final position.

This changes the progress calculation to:
* Use total elapsed time rather than incrementing the delta of each call, and
* Clamp the progress to 1.0.